### PR TITLE
Updates to support python 3.x and twisted 16.x

### DIFF
--- a/bayeux/bayeux_client.py
+++ b/bayeux/bayeux_client.py
@@ -1,17 +1,17 @@
-import bayeux_constants
+from . import bayeux_constants
 import collections
 import json
 import logging
-import zope.interface
+from zope.interface import implementer
 from threading import Timer, Thread, RLock
 from twisted.internet import reactor
-from bayeux_message_receiver import BayeuxMessageReceiver
-from bayeux_message_sender import BayeuxMessageSender
+from .bayeux_message_receiver import BayeuxMessageReceiver
+from .bayeux_message_sender import BayeuxMessageSender
 
-from interfaces import IMessengerService
+from .interfaces import IMessengerService
 
+@implementer(IMessengerService)
 class BayeuxClient(object):
-    zope.interface.implements(IMessengerService)
     """Client that implements the bayeux protocol.
 
     User of this class should call register to register for 

--- a/bayeux/bayeux_message_receiver.py
+++ b/bayeux/bayeux_message_receiver.py
@@ -52,7 +52,7 @@ class BayeuxMessageReceiver(Protocol):
             data: The data string that was sent from the bayeux server
         """
         logging.debug('dataReceived: %s' % data)
-        self.buf += data
+        self.buf += data.decode()
 
     def connectionLost(self, reason):
         """Called after an entire message is received.
@@ -71,8 +71,8 @@ class BayeuxMessageReceiver(Protocol):
                 if 'channel' in msg:
                     self.notify(msg['channel'], msg)
         except ValueError as e:
-            print 'Error parsing data: ', self.buf
-            print e
+            logging.error('Error parsing data: ' + self.buf)
+            logging.error(e)
             if self.deliver_d is not None:
                 self.deliver_d.errback(e)
         self.buf = ''


### PR DESCRIPTION
Twisted has come a long way in the last few months and they've ported everything needed for the Bayeux client to Python 3.  With a few minor adjustments, the Bayeux client now supports Python 3 as well.  I also verified that the client still works properly in 2.7.
